### PR TITLE
Update acceptToken.js

### DIFF
--- a/lib/Strategy/acceptToken.js
+++ b/lib/Strategy/acceptToken.js
@@ -39,7 +39,8 @@ const acceptToken = async (strategy, req, options) => {
     // If you using a persistent token storage you might want to
     // regularly prune expired tokens
     Object.keys(usedTokens).forEach(token => {
-      const expiration = usedTokens[token];
+      // JWT expiration dates are set in seconds, not milliseconds
+      const expiration = usedTokens[token] * 1000;
       if (expiration <= Date.now()) {
         delete usedTokens[token];
       }


### PR DESCRIPTION
Pruning would catch all used tokens, not just expired ones.

(Maybe I'm missing something, but… why is there an expiration check at all? If it's used, shouldn't it just be wipe regardless?